### PR TITLE
Fix migrations and make user email unique

### DIFF
--- a/migrations/Version20211206191122.php
+++ b/migrations/Version20211206191122.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211206191122 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2D2CCB81E7927C74 ON admin_member (email)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_2D2CCB81E7927C74 ON admin_member');
+    }
+}

--- a/src/Controller/MemberController.php
+++ b/src/Controller/MemberController.php
@@ -75,13 +75,19 @@ class MemberController extends AbstractController {
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
-            $em->persist($member);
-            $em->flush();
-
-            return $this->render('user/apply.html.twig', [
-                'success' => true
-            ]);
+            $memberRepository = $this->getDoctrine()->getRepository(Member::class);
+            $existingMember = $memberRepository->findOneByEmail($member->getEmail());
+            if ($existingMember !== null) {
+                $form->addError(new FormError('Er is al een lid met dit e-mailadres.'));
+            } else {
+                $em = $this->getDoctrine()->getManager();
+                $em->persist($member);
+                $em->flush();
+    
+                return $this->render('user/apply.html.twig', [
+                    'success' => true
+                ]);
+            }
         }
 
         return $this->render('user/apply.html.twig', [

--- a/src/Entity/Member.php
+++ b/src/Entity/Member.php
@@ -37,7 +37,7 @@ class Member implements UserInterface {
     private string $lastName = '';
 
     /**
-     * @ORM\Column(type="string", length=200, nullable=true)
+     * @ORM\Column(type="string", length=200, nullable=true, unique=true)
      * @Assert\Email
      */
     private ?string $email = null;


### PR DESCRIPTION
Fixes #32 

Dit vereist een handmatig commando op de server. In plaats van `doctrine:schema:create` werkt het nu met een initiele migratie. Dit is als het goed is precies het schema dat nu op de database server staat, daarom kan deze migratie overgeslagen worden op de productie database. Dat kan met dit commando:

```bash
symfony console doctrine:migrations:version 'DoctrineMigrations\Version20211204213452' --add
```

Daarna kan de nieuwe migratie worden uitgevoerd om email van members uniek te maken. Dat gaat met
```bash
symfony console doctrine:migrations:migrate
```

Als alle emails uniek zijn in de database gaat dit helemaal goed. 

Momenteel laat dit de volgende error zien in de aanmeld form: "Er is al een lid met dit e-mailadres.". Deze heb ik gekopieerd van de support member form. Ik kon niks duidelijks verzinnen dat niet verraad dat het iemands e-mailadres is.

In de admin is er een mooie 500 error, want ik weet niet zo goed hoe ik easyadmin aanpas