### PR TITLE
Tell fastcgi we're on https

### DIFF
--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -55,6 +55,9 @@ http {
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
 
+            fastcgi_param  REQUEST_SCHEME     "https";
+            fastcgi_param  HTTPS              "on";
+
             # optionally set the value of the environment variables used in the application
             # fastcgi_param APP_ENV prod;
             # fastcgi_param APP_SECRET <app-secret-id>;


### PR DESCRIPTION
Nginx/fastcgi think we're not on https because the request is already forwarded from the host nginx. The proper solution to this is to have nginx interpret the `x-forwarded-for` etc headers, but i'm not very sure how to do that yet