### PR TITLE
Sort events correctly

### DIFF
--- a/src/Controller/MemberController.php
+++ b/src/Controller/MemberController.php
@@ -73,6 +73,7 @@ class MemberController extends AbstractController {
             ->andWhere('e.timeEnd > ?2')
             ->setParameter(1, $member->getDivision())
             ->setParameter(2, new DateTime())
+            ->orderBy('e.timeStart', 'ASC')
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
They are sorted on ID by default but should be sorted on their start date instead