### PR TITLE
*: use database instead of php as session storage, configure timeout of 1 hour

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=...................................
-COOKIE_DOMAIN=.rood.example
+COOKIE_DOMAIN=localhost
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -7,7 +7,7 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: null
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
         cookie_secure: auto
         cookie_samesite: strict
         cookie_domain: '%env(COOKIE_DOMAIN)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -53,3 +53,8 @@ services:
             - '%env(DIRECTADMIN_URL)%'
             - '%env(DIRECTADMIN_USERNAME)%'
             - '%env(DIRECTADMIN_PASSWORD)%'
+
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments:
+            - '%env(DATABASE_URL)%'
+            - { 'ttl': 3600 }

--- a/migrations/Version20230401114746.php
+++ b/migrations/Version20230401114746.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230401114746 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE `sessions` (`sess_id` VARBINARY(128) NOT NULL PRIMARY KEY, `sess_data` BLOB NOT NULL, `sess_lifetime` INTEGER UNSIGNED NOT NULL, `sess_time` INTEGER UNSIGNED NOT NULL, INDEX `sessions_sess_lifetime_idx` (`sess_lifetime`)) COLLATE utf8mb4_bin, ENGINE = InnoDB');
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE `sessions`');
+    }
+}


### PR DESCRIPTION
This should move session storage to the mariadb database instead of the default php. This allows us to configure a timeout for sessions and should in theory fix the login problems. Database migration is required.

Documentation on this is here: https://symfony.com/doc/current/session.html

Also fixes the `.env` file to work out of the box and not give this invalid CFRS error.