### PR TITLE
Add membershipstatus

### DIFF
--- a/migrations/Version20240218160940.php
+++ b/migrations/Version20240218160940.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240218160940 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add membership status';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE admin_membershipstatus (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(150) NOT NULL, allowed_access TINYINT(1) DEFAULT \'0\' NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE admin_member ADD current_membership_status_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE admin_member ADD CONSTRAINT FK_2D2CCB81E1F48A9F FOREIGN KEY (current_membership_status_id) REFERENCES admin_membershipstatus (id)');
+        $this->addSql('CREATE INDEX IDX_2D2CCB81E1F48A9F ON admin_member (current_membership_status_id)');
+        $this->addSql("INSERT INTO admin_membershipstatus VALUES (1, 'Lid', TRUE)");
+        $this->addSql("UPDATE admin_member SET current_membership_status_id = 1");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE admin_member DROP FOREIGN KEY FK_2D2CCB81E1F48A9F');
+        $this->addSql('DROP TABLE admin_membershipstatus');
+        $this->addSql('DROP INDEX IDX_2D2CCB81E1F48A9F ON admin_member');
+        $this->addSql('ALTER TABLE admin_member DROP current_membership_status_id');
+    }
+}

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Component\HttpFoundation\Response;
 use EasyCorp\Bundle\EasyAdminBundle\Config\{ Crud, Dashboard, MenuItem };
 use App\Entity\{ Member, SupportMember, MembershipApplication, Division, Email, EmailDomain, Event };
+use App\Entity\Membership\MembershipStatus;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Asset\Packages;
@@ -62,6 +63,7 @@ class DashboardController extends AbstractDashboardController
             MenuItem::linkToCrud('Steunleden', 'fa fa-users', SupportMember::class)->setPermission('ROLE_ADMIN'),
             MenuItem::linkToCrud('Aanmeldingen', 'fa fa-user-plus', MembershipApplication::class)->setPermission('ROLE_ADMIN'),
             MenuItem::linkToCrud('Groepen', 'fa fa-building', Division::class)->setPermission('ROLE_ADMIN'),
+            MenuItem::linkToCrud('Lidmaatschapstypes', 'fa fa-building', MembershipStatus::class)->setPermission('ROLE_ADMIN'),
 
             MenuItem::section('Technisch')->setPermission('ROLE_ADMIN'),
             MenuItem::linkToCrud('E-mailadressen', 'fa fa-at', Email::class)->setPermission('ROLE_ADMIN'),

--- a/src/Controller/Admin/Membership/MembershipStatusCrud.php
+++ b/src/Controller/Admin/Membership/MembershipStatusCrud.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Controller\Admin\Membership;
+
+use App\Entity\Membership\MembershipStatus;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\{ IdField, FormField, BooleanField, DateField, DateTimeField, CollectionField, ChoiceField, TextField, TextEditorField, EmailField, AssociationField, MoneyField };
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+
+class MembershipStatusCrud extends AbstractCrudController
+{
+    // it must return a FQCN (fully-qualified class name) of a Doctrine ORM entity
+    public static function getEntityFqcn(): string
+    {
+        return MembershipStatus::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Lidmaatschapstype')
+            ->setEntityLabelInPlural('Lidmaatschapstypes')
+            ->setEntityPermission('ROLE_ADMIN')
+        ;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id', 'ID')->hideOnForm(),
+            TextField::new('name', 'Naam'),
+            BooleanField::new('allowedAccess', 'Heeft toegang'),
+        ];
+    }
+}

--- a/src/Entity/Membership/MembershipStatus.php
+++ b/src/Entity/Membership/MembershipStatus.php
@@ -1,0 +1,50 @@
+<?php
+namespace App\Entity\Membership;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\{ ArrayCollection, Collection };
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Entity\Member;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table("admin_membershipstatus")
+ */
+class MembershipStatus {
+
+    /**
+     * @ORM\Column(type="integer", options={ "unsigned": false })
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", length=150)
+     */
+    private string $name = '';
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Member", mappedBy="currentMembershipStatus")
+     */
+    private Collection $members;
+
+    /**
+     * @ORM\Column(type="boolean", nullable=false, options={"default": false})
+     */
+    private bool $allowedAccess = false;
+
+    public function __toString() {
+        return $this->name;
+    }
+
+    public function getId(): ?int { return $this->id; }
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): void { $this->name = $name; }
+
+    public function getAllowedAccess(): bool { return $this->allowedAccess; }
+    public function setAllowedAccess(bool $allowedAccess) { $this->allowedAccess = $allowedAccess; }
+
+    public function getMembers(): Collection { return $this->members; }
+}


### PR DESCRIPTION
The members lacked a status field which made it hard to keep track of whether members were ex-members, members, expelled, cancelled their membership etc.

This introduces arbitrary fields of membership statuses that are being able to be set by the administrators.

The migration makes a single membership type in advance which is called "Lid" (member) and everyone by default will be made member and get access to the login.

You can make additional membership types which can't login to the system at all.