### PR TITLE
Add ability to add custom welcome template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules
 public/assets
 public/bundles
 docker/mysql
+templates/custom

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Look at `src/DataFixtures/` to see an overview of all test data, including other
 
 To add a custom welcome email, put the two templates (html and plain text) in:
 
-`templates/custom/email/welcome.html.twig` and `templates/custom/email/welcome.html.txt`
+`templates/custom/email/html/welcome.html.twig` and `templates/custom/email/text/welcome.html.txt`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Go to `http://localhost:8080/` and you should be greeted by the MijnRood login p
 You can log in with `admindebaas@example.com` as email, and `admin` as password.
 Look at `src/DataFixtures/` to see an overview of all test data, including other accounts.
 
+## Extra configuration
+
+### Custom welcome mail
+
+To add a custom welcome email, put the two templates (html and plain text) in:
+
+`templates/custom/email/welcome.html.twig` and `templates/custom/email/welcome.html.txt`
+
 ## Contributing
 
 You can generate new migrations with:

--- a/src/Controller/Admin/MembershipApplicationCrud.php
+++ b/src/Controller/Admin/MembershipApplicationCrud.php
@@ -128,15 +128,21 @@ class MembershipApplicationCrud extends AbstractCrudController
         $em->remove($application);
         $em->flush();
 
+	$templatePrefix = '';
+
+	if (is_dir($this->getParameter('kernel.project_dir') . '/templates/custom')) {
+	    $templatePrefix = 'custom/';
+	}
+
         $message = (new Email())
             ->subject("Welkom bij $organizationName!")
             ->to(new Address($member->getEmail(), $member->getFullName()))
             ->from(new Address($noreply,$organizationName))
             ->html(
-                $this->renderView('email/html/welcome.html.twig', ['member' => $member])
+                $this->renderView($templatePrefix . 'email/html/welcome.html.twig', ['member' => $member])
             )
             ->text(
-                $this->renderView('email/text/welcome.txt.twig', ['member' => $member])
+                $this->renderView($templatePrefix . 'email/text/welcome.txt.twig', ['member' => $member])
             );
         $mailer->send($message);
 


### PR DESCRIPTION
This adds the ability to add a custom welcome template. It works by simply adding a custom folder in the templates directory and putting a email/html/welcome.html.twig and email/text/welcome.txt.twig there (as you can read in the README).