### PR TITLE
[172] Filter properly on managed divisions

### DIFF
--- a/src/Entity/Division.php
+++ b/src/Entity/Division.php
@@ -25,7 +25,7 @@ class Division {
     private string $name = '';
 
     /**
-     * @ORM\ManyToMany(targetEntity="Member")
+     * @ORM\ManyToMany(targetEntity="Member", inversedBy="managed_divisions")
      * @ORM\JoinTable(name="division_member")
      */
     private Collection $contacts;

--- a/src/Entity/Member.php
+++ b/src/Entity/Member.php
@@ -93,6 +93,12 @@ class Member implements UserInterface {
     private ?Division $division = null;
 
     /**
+     * @ORM\ManyToMany(targetEntity="Division", inversedBy="contacts")
+     * @ORM\JoinTable(name="division_member")
+     */
+    private Collection $managed_divisions;
+
+    /**
      * @ORM\Column(type="date", nullable=true)
      */
     private ?DateTime $registrationTime = null;
@@ -228,6 +234,8 @@ class Member implements UserInterface {
 
     public function getDivision(): ?Division { return $this->division; }
     public function setDivision(?Division $division): void { $this->division = $division; }
+
+    public function getManagedDivisions(): Collection { return $this->managed_divisions; }
 
     public function getRegistrationTime(): ?DateTime { return $this->registrationTime; }
     public function setRegistrationTime(?DateTime $registrationTime): void { $this->registrationTime = $registrationTime; }


### PR DESCRIPTION
Rarely, it is possible for division admins to manage multiple divisions, for example if they have to temporarily take over a different division. This changes allows them to see the data of all the divisions that they managed.

Solves #172 