### PR TITLE
fix: server error on payment cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ public/assets
 public/bundles
 docker/mysql
 templates/custom
+
+# JetBrains IDE files
+.idea/

--- a/src/Controller/Admin/MemberCrud.php
+++ b/src/Controller/Admin/MemberCrud.php
@@ -90,6 +90,7 @@ class MemberCrud extends AbstractCrudController
         $subscription = $mollieApiClient->subscriptions->getFor($customer, $member->getMollieSubscriptionId());
         $subscription->cancel();
         $member->setMollieSubscriptionId(null);
+        $em = $this->getDoctrine()->getManager();
         $em->flush();
         return new Response('Membership cancelled succesfully');
     }


### PR DESCRIPTION
This PR fixes the 500 Internal Server Error when an admin uses the button to end a members due payments. The problem was that there was a line missing to flush the database after the change, causing an undefined variable error.

This PR also improves UI when performing this operation, showing a flash message to the user. This message is now also in Dutch, like the rest of the UI.