### PR TITLE
feat(checkin): added a page to checkin/out members

### DIFF
--- a/assets/check-in.js
+++ b/assets/check-in.js
@@ -1,0 +1,169 @@
+import 'fork-awesome/css/fork-awesome.min.css';
+import './style/check-in.less';
+
+function updateStats(statistics) {
+    $('#checked-in-count').text(statistics.checkedInWithReservations + statistics.checkedInWithoutReservations);
+    $('#reserved-count').text(statistics.reservations);
+    $('#not-checked-in-count').text(statistics.reservations - statistics.checkedInWithReservations);
+    $('#checked-in-without-reservation-count').text(statistics.checkedInWithoutReservations);
+}
+
+let statsRequest;
+function fetchStats() {
+    const route = 'event_stats';
+    const statsUrl = Routing.generate(route, { eventId: 1 }, true);
+    statsRequest?.abort();
+    statsRequest = $.get(statsUrl)
+        .done(updateStats)
+        .fail(() => console.error('Failed to fetch stats'));
+}
+
+// Create a template for the user row
+const userRowTemplate = (user) => `
+    <div class="table-row ${user.checkedIn ? 'checked-in' : ''}">
+        <div>${user.firstname}</div>
+        <div>${user.fullLastname}</div>
+        <div>${user.divisionName}</div>
+        <div>
+            <i class="fa fa-fw ${user.reserved ? 'fa-check' : 'fa-times'}" style="color:${user.reserved ? 'green' : 'red'}"></i>
+        </div>
+        <div>
+            <a href="#" class="${user.checkedIn ? 'btn-check-out' : 'btn-check-in'}" data-id="${user.id}" style="${user.checkedIn ? 'opacity: 0.5' : ''}">
+                <i class="fa fa-fw ${user.checkedIn ? 'fa-minus' : 'fa-plus'}"></i>
+                ${user.checkedIn ? 'Uitchecken' : 'Inchecken'}
+            </a>
+        </div>
+    </div>
+`;
+
+function populateTableBody(users) {
+    const tableBody = $('.table-body');
+    tableBody.empty(); // Clear existing rows
+    users.forEach(user => {
+        tableBody.append(userRowTemplate(user));
+    });
+    initializeEventHandlers();
+}
+
+function refreshTableBody(users) {
+    fetchStats();
+    populateTableBody(users);
+}
+
+function handleCheckInOut(action, userId) {
+    const route = action === 'check-in' ? 'event_check_in' : 'event_check_out';
+    const actionUrl = Routing.generate(route, { eventId: 1 }, true);
+    $.post(actionUrl, { userId: userId })
+        .done(() => {
+            const user = userData.find(u => u.id == userId);
+            user.checkedIn = action === 'check-in';
+            refreshTableBody(userData);
+        })
+        .fail(() => console.error(`Failed to ${action} user`));
+}
+
+function initializeEventHandlers() {
+    $('.btn-check-in').on('click', function (e) {
+        e.preventDefault();
+        handleCheckInOut('check-in', $(this).data('id'));
+    });
+
+    $('.btn-check-out').on('click', function (e) {
+        e.preventDefault();
+        handleCheckInOut('check-out', $(this).data('id'));
+    });
+}
+
+const pageTemplate = (num) => `
+    <div data-page="${num}" class="pageNum${num === currentPage ? ' active' : ''}">${num}</div>
+`;
+
+function updatePagination() {
+    const paginationIndicator = $('.pagination-indicator');
+    paginationIndicator.empty();
+    if (totalPages === 1) return;
+    for (let index = 1; index <= totalPages; index++) {
+        paginationIndicator.append(pageTemplate(index));
+    }
+    initializePaginationHandlers();
+}
+
+function initializePaginationHandlers() {
+    $('.pageNum').on('click', function (e) {
+        e.preventDefault();
+        const selectedPage = $(this).data('page');
+        if (currentPage === selectedPage) return; // skip fetching if it is the same page
+        currentPage = selectedPage;
+        fetchMembers();
+    });
+}
+
+let ascendingColumns = [];
+let descendingColumns = [];
+let searchQuery = "";
+let searchRequest;
+let currentPage = 1;
+let userData = [];
+let totalCount = 0;
+let totalPages = 1;
+
+function fetchMembers() {
+    const route = 'event_attendees';
+    const membersUrl = Routing.generate(route, { eventId: 1 }, true);
+    searchRequest?.abort();
+    searchRequest = $.get(membersUrl, {
+        ascending: ascendingColumns,
+        descending: descendingColumns,
+        search: searchQuery,
+        page: currentPage
+    })
+    .done((response) => {
+        userData = response.results;
+        totalCount = response.amount;
+        totalPages = response.pages;
+
+        if (currentPage > totalPages) {            
+            currentPage = 0; // Reset to the first page if out of bounds
+            fetchMembers();
+            return;
+        }
+
+        refreshTableBody(userData);
+        updatePagination();
+    })
+    .fail(() => console.error('Failed to fetch members'));
+}
+
+$(document).ready(function () {
+    $('#search-input').on('input', function() {
+        searchQuery = $(this).val();
+        fetchMembers();
+    });
+
+    $('#clear-search-button').on('click', function() {
+        $('#search-input').val('');
+        searchQuery = '';
+        fetchMembers();
+    });
+
+    $('.table-header .header-cell').on('click', function (e) {
+        const column = $(this).data("column");
+        const ascIndex = ascendingColumns.indexOf(column);
+        const descIndex = descendingColumns.indexOf(column);
+        
+        if (ascIndex !== -1) {            
+            ascendingColumns.splice(ascIndex, 1);
+            descendingColumns.push(column);
+            $(this).find('i').attr('class', 'fa fa-sort-down');
+        } else if (descIndex !== -1) {
+            descendingColumns.splice(descIndex, 1);
+            $(this).find('i').attr('class', 'fa fa-sort');
+        } else {
+            ascendingColumns.push(column);
+            $(this).find('i').attr('class', 'fa fa-sort-up');
+        }
+        fetchMembers();
+    });
+
+    fetchMembers(); // Initial fetch of members
+});

--- a/assets/members.js
+++ b/assets/members.js
@@ -1,1 +1,22 @@
 import './style/members.less';
+
+$(document).ready(function () {
+  $('.reserve').on('click', function (e) {
+    const eventId = e.currentTarget.getAttribute("data");
+    let route = 'event_reserve';
+    let renameUrl = Routing.generate(route, { ["event" + 'Id']: eventId }, true);
+    $.post(renameUrl, {
+    }, function (r) {
+      window.location.reload()
+    }, 'JSON');
+  });
+  $('.dereserve').on('click', function (e) {
+    const eventId = e.currentTarget.getAttribute("data");
+    let route = 'event_dereserve';
+    let renameUrl = Routing.generate(route, { ["event" + 'Id']: eventId }, true);
+    $.post(renameUrl, {
+    }, function (r) {
+      window.location.reload()
+    }, 'JSON');
+  });
+})

--- a/assets/style/check-in.less
+++ b/assets/style/check-in.less
@@ -1,0 +1,164 @@
+@import './common.less';
+
+@font-family: Arial, sans-serif;
+@primary-color: #007bff;
+@border-color: #ddd;
+@background-color: #f2f2f2;
+@hover-background-color: #f9f9f9;
+
+.event-details {
+    margin: 20px;
+
+    .event-image {
+        // Add styles for the event image if needed
+    }
+
+    .event-info {
+        .event-name {
+            font-size: 1.5em;
+            font-weight: bold;
+        }
+
+        .event-date,
+        .event-organizer,
+        .event-description {
+            display: block;
+            margin: 5px 0;
+        }
+    }
+
+    .registrations-section {
+        margin-top: 20px;
+
+        .registrations-title {
+            font-size: 1.2em;
+            margin-bottom: 10px;
+        }
+
+        .registrations-stats {
+            margin-bottom: 20px;
+            font-size: 14px;
+
+            div {
+                span {
+                    font-weight: bold;
+                }
+            }
+        }
+
+        .search-section {
+            display: flex;
+            align-items: center;
+            margin-bottom: 20px;
+
+            .search-input {
+                flex: 1;
+                padding: 10px;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+                margin-right: 10px;
+            }
+
+            .clear-search {
+                cursor: pointer;
+                color: @rood; // Use the defined color variable
+            }
+        }
+
+        .pagination-indicator {
+            color: @rood; // Use the defined color variable
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            gap: 4px;
+
+            .pageNum {
+                cursor: pointer;
+
+                &.active {
+                    font-weight: bold;
+                    text-decoration: underline;
+                }
+            }
+        }
+
+        .data-table {
+            border-collapse: collapse;
+            width: 100%;
+
+            .table-header {
+                background-color: @background-color;
+                font-weight: bold;
+                display: flex;
+                flex-wrap: wrap;
+
+                .header-cell {
+                    padding: 10px;
+                    border: 1px solid @border-color;
+                    flex: 1; // Default flex for equal space
+
+                    // Specific widths for the last two columns
+                    &:nth-child(3), // Aangemeld
+                    &:nth-child(4) { // Ingechecked
+                        flex: 0 0 150px; // Fixed width for these columns
+                        text-align: center; // Center align for better appearance
+                    }
+
+                    // Style for sort icons
+                    i {
+                        margin-left: 5px;
+                        cursor: pointer;
+                    }
+                }
+            }
+
+            .table-body {
+                background-color: #fff;
+
+                .table-row {
+                    display: flex;
+                    flex-wrap: wrap;
+                    border-bottom: 1px solid @border-color;
+
+                    div {
+                        padding: 10px;
+                        flex: 1;
+
+                        // Center align for the last two columns
+                        &:nth-child(3), // Aangemeld
+                        &:nth-child(4) { // Ingechecked
+                            flex: 0 0 150px; // Fixed width for these columns
+                            text-align: center;
+                        }
+                    }
+
+                    &:hover {
+                        background-color: @hover-background-color; // Use the defined hover color
+                    }
+                }
+
+                .checked-in {
+                    background-color: rgb(200, 200, 200);
+
+                    &:hover {
+                        background-color: @hover-background-color; // Use the defined hover color
+                    }
+                }
+            }
+        }
+
+        .btn-check-in, .btn-check-out {
+            text-decoration: none;
+            color: @rood; // Use the defined color variable
+            padding: 5px 10px;
+            border: 1px solid @rood; // Use the defined color variable
+            border-radius: 4px;
+
+            &:hover {
+                background-color: @rood; // Use the defined color variable
+                color: white;
+                border-color: white;
+            }
+        }
+    }
+}

--- a/assets/style/members.less
+++ b/assets/style/members.less
@@ -52,8 +52,15 @@ h1, h2, h3 {
         .event-description {
             margin: 10px 0;
         }
+    }
 
-
+    .event-attendance {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        span {
+            cursor: pointer;
+        }
     }
 }
 

--- a/migrations/Version20250525151750.php
+++ b/migrations/Version20250525151750.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250525151750 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE admin_event_attendant (event_id INT UNSIGNED NOT NULL, member_id INT NOT NULL, reserved DATETIME DEFAULT NULL, checked_in TINYINT(1) DEFAULT 0 NOT NULL, INDEX IDX_8155D4B71F7E88B (event_id), INDEX IDX_8155D4B7597D3FE (member_id), PRIMARY KEY(event_id, member_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE admin_event_attendant ADD CONSTRAINT FK_8155D4B71F7E88B FOREIGN KEY (event_id) REFERENCES admin_event (id)');
+        $this->addSql('ALTER TABLE admin_event_attendant ADD CONSTRAINT FK_8155D4B7597D3FE FOREIGN KEY (member_id) REFERENCES admin_member (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE admin_event_attendant DROP FOREIGN KEY FK_8155D4B71F7E88B');
+        $this->addSql('ALTER TABLE admin_event_attendant DROP FOREIGN KEY FK_8155D4B7597D3FE');
+        $this->addSql('DROP TABLE admin_event_attendant');
+    }
+}

--- a/src/Controller/CheckInController.php
+++ b/src/Controller/CheckInController.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\{ Member, Event, EventAttendant};
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\{ JsonResponse, Response, Request };
+use Symfony\Component\Routing\Annotation\Route;
+
+use DateTime;
+
+class CheckInController extends AbstractController
+{
+    /**
+    * @Route("/evenement/{eventId<\d+>}", name="event_inchecker", options={"expose": true},)
+    */
+    public function index(Request $request, $eventId): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN'))
+            throw $this->createAccessDeniedException('Je mag hier niet komen.');
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        $contributionEnabled = $this->getParameter('app.contributionEnabled');
+
+        return $this->render('user/check-in.html.twig', 
+        [
+            'event' => $event,
+            'stats' => $this->getAttendentInfo($event),
+	        'contributionEnabled' => $contributionEnabled,
+        ]);
+    }
+
+    /**
+     * Get the attendant data so we know how much people reserved and are checked in.
+     */
+    private function getAttendentInfo(Event $event)
+    {
+        return [
+            'reservations'=> count($event->getReservedAttendants()),
+            'checkedInWithReservations'=> count($event->getCheckedInWithReservation()),
+            'checkedInWithoutReservations'=> count($event->getCheckedInWithoutReservation()),
+        ];
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/stats", name="event_stats", options={"expose": true}, methods={"GET"})
+    */
+    public function getStats(Request $request, $eventId): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN'))
+            throw $this->createAccessDeniedException('Je mag hier niet komen.');
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        return new JsonResponse($this->getAttendentInfo($event));
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/checkin", name="event_check_in", options={"expose": true}, methods={"POST"})
+    */
+    public function checkin(Request $request, $eventId): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN'))
+            throw $this->createAccessDeniedException('Je mag hier niet komen.');
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        if (!$request->request->has('userId'))
+            return $this->json(['status' => 'missing-fields', 'missing-fields' => ['userId']]);
+
+        # if admin or assigned to this event
+        $userId = $request->request->get('userId');
+        $user = $this->getDoctrine()->getRepository(Member::class)->find($userId);
+        $this->checkAttendant($event, $user, true);
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/checkout", name="event_check_out", options={"expose": true}, methods={"POST"})
+    */
+    public function checkout(Request $request, $eventId): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN'))
+            throw $this->createAccessDeniedException('Je mag hier niet komen.');
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        if (!$request->request->has('userId'))
+            return $this->json(['status' => 'missing-fields', 'missing-fields' => ['userId']]);
+
+        # if admin or assigned to this event
+        $userId = $request->request->get('userId');
+        $user = $this->getDoctrine()->getRepository(Member::class)->find($userId);
+        $this->checkAttendant($event, $user, false);
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Check a member in or out on the given event
+     */
+    private function checkAttendant(Event $event, Member $member, bool $checkedIn){
+        $attendant = $this->getDoctrine()->getRepository(EventAttendant::class)
+        ->findOneBy(['event' => $event, 'member' => $member]);
+        if ($attendant == null){
+            $attendant = new EventAttendant();
+            $attendant->setMember($member);
+            $attendant->setEvent($event);
+        }
+
+        $attendant->setCheckedIn($checkedIn);
+
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($attendant);
+        $em->flush();
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/reserve", name="event_reserve", options={"expose": true}, methods={"POST"})
+    */
+    public function reserve(Request $request, $eventId): Response
+    {
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        $attendant = $this->getDoctrine()->getRepository(EventAttendant::class)
+        ->findOneBy(['event' => $event, 'member' => $member]);
+        if ($attendant == null) {    
+            $attendant = new EventAttendant();
+            $attendant->setMember($member);
+            $attendant->setEvent($event);
+        }
+        $attendant->setReserved(new DateTime());
+
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($attendant);
+        $em->flush();
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/dereserve", name="event_dereserve", options={"expose": true}, methods={"POST"})
+    */
+    public function dereserve(Request $request, $eventId): Response
+    {
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        $attendant = $this->getDoctrine()->getRepository(EventAttendant::class)
+        ->findOneBy(['event' => $event, 'member' => $member]);
+
+        $attendant->setReserved(null);
+    
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($attendant);
+        $em->flush();
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+    * @Route("/evenement/{eventId<\d+>}/attendees", name="event_attendees", options={"expose": true}, methods={"GET"})
+    */
+    public function getAttendees(Request $request, $eventId): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN'))
+            throw $this->createAccessDeniedException('Je mag hier niet komen.');
+        $member = $this->getUser();
+        $event = $this->getDoctrine()->getRepository(Event::class)->find($eventId);
+
+        // get arguments from request
+        $searchTerm = $request->query->get('search', "");
+        $ascCols = $request->query->all('ascending', []);
+        $descCols = $request->query->all('descending', []);
+        $page = $request->query->get('page', 1);
+
+        // create the select query, to be reused by where clauses
+        $selectQuery = [
+            "id" => 'm.id',
+            "firstname" => 'm.firstName',
+            "lastname" => 'm.lastName',
+            "fullLastname" => 'TRIM(
+                  CONCAT(m.middleName, \' \', m.lastName)
+                  )',
+            "fullname" => 'CONCAT(
+                 TRIM(
+                  CONCAT(m.firstName, \' \', m.middleName)
+                  ), 
+                  \' \', 
+                  m.lastName
+                )',
+            "divisionName" => 'COALESCE(d.name, \'\')',
+            "reserved" => 'CASE WHEN ea.reserved IS NOT NULL THEN true ELSE false END',
+            "checkedIn" => 'COALESCE(ea.checkedIn, false)',
+        ];
+
+        // build base query
+        $stmts = [];
+        foreach ($selectQuery as $alias => $stmt) {
+            array_push($stmts, $stmt . " AS " . $alias);
+        }
+        $selectString = join(', ', $stmts);
+        $query = $this->getDoctrine()->getRepository(Member::class)
+            ->createQueryBuilder('m')
+            ->select($selectString)
+            ->leftJoin('m.division', 'd')
+            ->leftJoin('m.eventsAttended', 'ea', 'WITH', 'ea.event = :eventId')
+            ->setParameter('eventId', $eventId);
+            
+        // add search condition to query, if given
+        if (strlen($searchTerm) > 0){
+            $query
+            ->where($selectQuery['fullname'] .' LIKE :nameSearch')
+            ->setParameter('nameSearch', '%' . $searchTerm . '%')
+            ->orWhere($selectQuery['divisionName'] . ' LIKE :divisionSearch')
+            ->setParameter('divisionSearch', '%' . $searchTerm . '%');
+        }
+
+        // Get the amount of results of the query
+        $count = (clone $query)->select('count(m.id)')->getQuery()->getSingleScalarResult();
+
+        // get the columns to orderby
+        $cols = [
+            // name in request => columns in query
+            'isCheckedIn' =>'checkedIn',
+            'isReserved' =>'reserved',
+            'division' =>'divisionName',
+            'firstname' =>'firstname',
+            'lastname' =>'lastname',
+        ];
+        $orderbys = [];
+        foreach ($cols as $name => $col ) {
+            if (in_array($name, $ascCols)){
+                array_push( $orderbys, [$col, "ASC"]);
+            }
+            if (in_array($name, $descCols)){
+                array_push( $orderbys, [$col, "DESC"]);
+            }
+        }
+        // Add orderby clauses, if given
+        if (count($orderbys)){
+            foreach ($orderbys as $orderby) {
+                $col = $orderby[0];
+                $direction = $orderby[1];
+                $query->addOrderBy($col, $direction);
+            }
+        }
+        
+        // Paginate the resulsts
+        $amount = 25;
+        $offset = $amount * ($page - 1);
+        $query->setFirstResult($offset)
+            ->setMaxResults($amount);
+        $rows = $query->getQuery()->getResult();
+
+        
+        // Loop through each row and create a new dict with the keys we want to show
+        $responeSelect = [
+            'id',
+            'firstname',
+            'fullLastname',
+            'divisionName',
+            'reserved',
+            'checkedIn',
+        ];
+        $data = [];
+        foreach ($rows as $row) {
+            $item = [];
+            foreach ($responeSelect as $key) {
+                $item[$key] = $row[$key];
+            }
+            array_push($data, $item);
+        }
+
+        return new JsonResponse([
+            'results' => $data,
+            'amount' => $count,
+            'pages' => floor($count / $amount) + 1
+        ]);
+    }
+}

--- a/src/Controller/MemberController.php
+++ b/src/Controller/MemberController.php
@@ -87,6 +87,8 @@ class MemberController extends AbstractController {
 
         return $this->render('user/home.html.twig', [
             'events' => $events,
+            'member' => $member,
+            'isAdmin' => $this->isGranted('ROLE_ADMIN'),
 	    'contributionEnabled' => $contributionEnabled,
         ]);
     }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -45,6 +45,11 @@ class Event {
      */
     private DateTime $timeEnd;
 
+    /**
+     * @ORM\OneToMany(targetEntity="EventAttendant", mappedBy="event")
+     */
+    private Collection $attendants;
+
     public function __construct() {
 
     }
@@ -70,4 +75,36 @@ class Event {
         return $this->timeStart->format('Ymd') == $this->timeEnd->format('Ymd');
     }
 
+    public function getReservedAttendants() {
+        $items = [];
+        foreach ($this->attendants as $attendant) {
+            if ($attendant->getReserved() != null)
+            {
+                $items[] = $attendant;
+            }    
+        }
+        return $items;
+    }
+
+    public function getCheckedInWithReservation() {
+        $items = [];
+        foreach ($this->attendants as $attendant) {
+            if ($attendant->getReserved() != null && $attendant->isCheckedIn())
+            {
+                $items[] = $attendant;
+            }    
+        }
+        return $items;
+    }
+
+    public function getCheckedInWithoutReservation() {
+        $items = [];
+        foreach ($this->attendants as $attendant) {
+            if ($attendant->getReserved() == null && $attendant->isCheckedIn())
+            {
+                $items[] = $attendant;
+            }    
+        }
+        return $items;
+    }
 }

--- a/src/Entity/EventAttendant.php
+++ b/src/Entity/EventAttendant.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\{ Collection, ArrayCollection };
+use DateTime;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table("admin_event_attendant") 
+ */
+class EventAttendant {
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Event", inversedBy="attendants")
+     * @ORM\JoinColumn()
+     */
+    private Event $event;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Member", inversedBy="eventsAttended")
+     * @ORM\JoinColumn()
+     */
+    private Member $member;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private ?DateTime $reserved = null;
+
+    /**
+     * @ORM\Column(type="boolean", options={"default": false})
+     */
+    private bool $checkedIn = false;
+
+    public function __construct() {
+
+    }
+    // Getter and Setter for Event
+    public function getEvent(): Event
+    {
+        return $this->event;
+    }
+
+    public function setEvent(Event $event): self
+    {
+        $this->event = $event;
+        return $this;
+    }
+
+    // Getter and Setter for Member
+    public function getMember(): Member
+    {
+        return $this->member;
+    }
+
+    public function setMember(Member $member): self
+    {
+        $this->member = $member;
+        return $this;
+    }
+
+    // Getter and Setter for Reserved
+    public function getReserved(): ?DateTime
+    {
+        return $this->reserved;
+    }
+
+    public function setReserved(?DateTime $reserved): self
+    {
+        $this->reserved = $reserved;
+        return $this;
+    }
+
+    // Getter and Setter for CheckedIn
+    public function isCheckedIn(): bool
+    {
+        return $this->checkedIn;
+    }
+
+    public function setCheckedIn(bool $checkedIn): self
+    {
+        $this->checkedIn = $checkedIn;
+        return $this;
+    }
+}

--- a/src/Entity/Member.php
+++ b/src/Entity/Member.php
@@ -177,6 +177,11 @@ class Member implements UserInterface {
      */
     private ?string $comments = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="EventAttendant", mappedBy="member")
+     */
+    private Collection $eventsAttended;
+
     public function __construct() {
         $this->registrationTime = new DateTime;
         $this->contributionPayments = new ArrayCollection;
@@ -383,4 +388,22 @@ class Member implements UserInterface {
         $this->newPasswordTokenGeneratedTime = new DateTime();
     }
     public function getNewPasswordTokenGeneratedTime(): ?DateTime { return $this->newPasswordTokenGeneratedTime; }
+    
+    public function hasReserved(Event $event){
+        foreach ($this->eventsAttended as $attendedEvent) {
+            if ($event == $attendedEvent->getEvent()){
+                return $attendedEvent->getReserved() != null;
+            }
+        }
+        return false;
+    }
+
+    public function isCheckedIn(Event $event){
+        foreach ($this->eventsAttended as $attendedEvent) {
+            if ($event == $attendedEvent->getEvent()){
+                return $attendedEvent->isCheckedIn();
+            }
+        }
+        return false;
+    }
 }

--- a/templates/user/check-in.html.twig
+++ b/templates/user/check-in.html.twig
@@ -1,0 +1,60 @@
+{% extends 'user/layout/members.html.twig' %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('check-in') }}
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('check-in') }}
+{% endblock %}
+
+{% block content %}
+<div class="event-details">
+    <div class="event-image"></div>
+    
+    <div class="event-info">
+        <span class="event-name">{{ event.name }}</span>
+        <span class="event-date">
+            {{ event.timeStart|format_date('medium') }}
+            {% if not event.startsAndEndsOnSameDay %}
+                - {{ event.timeEnd|format_date('medium') }}
+            {% endif %}
+        </span>
+        <span class="event-organizer">
+            Georganiseerd door {{ event.division is null ? organisatienaam : event.division.name }}
+        </span>
+        <span class="event-description">{{ event.description|raw }}</span>
+    </div>
+
+    <div class="registrations-section">
+        <h2 class="registrations-title">Aanmeldingen</h2>
+        
+        <div class="registrations-stats">
+            <div>Ingechecked: <span id="checked-in-count">{{ stats.checkedInWithReservations + stats.checkedInWithoutReservations }}</span></div>
+            <div>Aangemeld: <span id="reserved-count">{{ stats.reservations }}</span></div>
+            <div>Verwacht: <span id="not-checked-in-count">{{ stats.reservations - stats.checkedInWithReservations }}</span></div>
+            <div>Ingechecked zonder aanmelding: <span id="checked-in-without-reservation-count">{{ stats.checkedInWithoutReservations }}</span></div>
+        </div>
+
+        <div class="search-section">
+            <input id="search-input" type="text" placeholder="Naam, Afdeling, Plaats..." class="search-input">
+            <div id="clear-search-button" class="clear-search">X</div>
+        </div>
+
+        <div class="pagination-indicator"></div>
+
+        <div class="data-table">
+            <div class="table-header">
+                <div class="header-cell" data-column="firstname">Voornaam <i class="fa fa-sort"></i></div>
+                <div class="header-cell" data-column="lastname">Achternaam <i class="fa fa-sort"></i></div>
+                <div class="header-cell" data-column="division">Afdeling <i class="fa fa-sort"></i></div>
+                <div class="header-cell" data-column="isReserved">Aangemeld <i class="fa fa-sort"></i></div>
+                <div class="header-cell" data-column="isCheckedIn">Ingechecked <i class="fa fa-sort"></i></div>
+            </div>
+            <div class="table-body"></div>
+        </div>
+    </div>    
+</div>
+{% endblock %}

--- a/templates/user/home.html.twig
+++ b/templates/user/home.html.twig
@@ -1,5 +1,15 @@
 {% extends 'user/layout/members.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('documents') }}
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    {{ encore_entry_script_tags('documents') }}
+{% endblock %}
+
 {% block content %}
     <div class="main-content">
         <h1><span class="rood">{{ organisatienaam }}</span></h1>
@@ -24,6 +34,25 @@
                     <span class="event-division">Georganiseerd door {{ event.division is null ? organisatienaam : event.division.name }}</span>
                     <span class="event-description">{{ event.description|raw }}</span>
                     {# <a href="{{ url('member_event') }}">Lees meer</a> #}
+                </div>
+                <div class="event-attendance">
+                    {% if member.hasReserved(event) != true %}
+                    <span class="reserve" data="{{event.id}}">
+                        <i class="fa fa-fw fa-plus"></i>
+                        Aanmelden
+                    </span>      
+                    {% else %}
+                    <span class="dereserve" data="{{event.id}}">
+                        <i class="fa fa-fw fa-times"></i>
+                        Afmelden
+                    </span>
+                    {% endif %}
+                    {% if isAdmin %}
+                        <a href="{{ url('event_inchecker', { eventId: event.getId() }) }}" class="btn-upload">
+                            Personen inchecken
+                            <i class="fa fa-fw fa-external-link"></i>
+                        </a>
+                    {% endif %}
                 </div>
             </div>
         {% else %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ Encore
     .addEntry('login', './assets/login.js')
     .addEntry('members', './assets/members.js')
     .addEntry('documents', './assets/documents.js')
+    .addEntry('check-in', './assets/check-in.js')
 
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()


### PR DESCRIPTION
In deze PR:
- nieuwe database tabel, tussen Member en Event
- Voor elke member op de home pagina een knop op een event om te reserveren
- Een pagina voor admins om mensen in en uit te checken (kunnen via een event op de home pagina daar komen)

Deze feature maakt het makkelijker om jezelf aan te melden omdat het nu via Mijn ROOD gaat. (en leden zullen vaker gebruik maken van mijn ROOD).
Ook moet dit het makkelijker maken om mensen in te kunnen checken op een ALV oid.
[checkin-demo.webm](https://github.com/user-attachments/assets/78d6e4f9-8acb-4114-9f7e-f593c7c3b66d)
