### PR TITLE
Restructure contribution options

### DIFF
--- a/config/instances/rood.yaml
+++ b/config/instances/rood.yaml
@@ -1,13 +1,19 @@
 contribution:
   tiers:
     - amount: 750
-      description: Tot en met €2000 bruto
+      description: Minimum
     - amount: 1500
-      description: €2000-€3499 bruto
-    - amount: 2250
-      description: €3500 bruto en daarboven
+      description: Basis
+    - amount: 2500
+      description: Minder
+    - amount: 3500
+      description: Gemiddeld
+    - amount: 5000
+      description: Hoog
+    - amount: 10000
+      description: Heel hoog
     - amount: null
-      description: ik betaal een hogere contributie, namelijk:
+      description: ik betaal een andere contributie, namelijk:
 signup:
   min_age: 14
   max_age: 27

--- a/src/Form/Contribution/ContributionIncomeType.php
+++ b/src/Form/Contribution/ContributionIncomeType.php
@@ -32,12 +32,19 @@ class ContributionIncomeType extends AbstractType
             }
         }
 
+        if(count($choices)%2 === 0){
+            $middle = (count($choices)-1)/2 + 1;
+        }else{
+            $middle = count($choices)/2;
+        }
+
         $builder
             ->add('contributionAmount', ChoiceType::class, [
                 'error_bubbling' => true,
                 'label' => 'Maandinkomen',
                 'choices' => $choices,
-                'expanded' => true
+                'expanded' => true,
+                'data' => array_values($choices)[$middle]
             ])
             ->add('otherAmount', MoneyType::class, [
                 'error_bubbling' => true,
@@ -52,7 +59,7 @@ class ContributionIncomeType extends AbstractType
                 ],
                 'constraints' => new Assert\GreaterThan([
                     'value' => $min_amount,
-                    'message' => 'Als je een hoger bedrag selecteert, moet dit hoger dan €' . number_format($min_amount / 100, 2, ',') . ' zijn.'
+                    'message' => 'Als je een ander bedrag selecteert, moet dit hoger dan €' . number_format($min_amount / 100, 2, ',') . ' zijn.'
                 ])
             ]);
 

--- a/templates/user/member/apply.html.twig
+++ b/templates/user/member/apply.html.twig
@@ -71,7 +71,7 @@
             {{ form_row(form.preferredDivision, { attr: { class: 'text-input' } }) }}
 
             <p>
-                Bij {{ orgnaamkort }} hebben we contributie op basis van je bruto maandinkomen. Selecteer wat er voor jou van toepassing is:
+                Bij {{ orgnaamkort }} heffen we contributie op basis van wat je kan missen. Selecteer hieronder wat voor jou van toepassing is:
             </p>
             <div class="choices">
                 {% for option in form.contributionPerPeriodInCents.contributionAmount %}


### PR DESCRIPTION
As discussed during the previous general assembly.

- drop references to income, instead instruct the user to pick what they can spare
- select the middle box by default instead of the first to encourage new members to pay more then the minimum


<img width="510" height="422" alt="Screenshot_20260201_143020" src="https://github.com/user-attachments/assets/7b1279d8-cbe4-4222-8525-f1ebd3728b9f" />
