### PR TITLE
Add bougie-based local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,53 @@
 
 # Setup
 
+There are two ways to run the project locally: with [bougie](https://bougie.tools) (recommended, no Docker needed) or with docker-compose.
+
+## Setup with bougie
+
+Bougie manages the PHP toolchain, the composer dependencies, and the dev services (MariaDB and an HTTP server) for this project, so you don't need PHP, Composer, or a database installed. The PHP version and services are declared in `composer.json` under `extra.bougie`.
+
+Install bougie:
+
+`curl -LsSf https://bougie.tools/install.sh | sh`
+
+Bring the project up. This installs PHP 8.1 with the required extensions, installs the composer dependencies, and starts the MariaDB and dev-server services:
+
+`bougie start`
+
+Bougie provisions a project-specific MariaDB database with generated credentials. These are only injected into `bougie run` commands, not into web requests, so write them to `.env.local` where Symfony picks them up everywhere:
+
+```sh
+bougie run -- sh -c 'echo "DATABASE_URL=\"mysql://$BOUGIE_SERVICE_MARIADB_USER:$BOUGIE_SERVICE_MARIADB_PASSWORD@localhost/$BOUGIE_SERVICE_MARIADB_DATABASE?serverVersion=mariadb-11.4.4&unix_socket=$BOUGIE_SERVICE_MARIADB_SOCKET\""' >> .env.local
+```
+
+Also add the testing `MOLLIE_API_KEY` to `.env.local`:
+
+`echo MOLLIE_API_KEY=test_................................. >> .env.local`
+
+The database itself is already created by bougie, so you only need to create the schema and load the test data:
+
+```sh
+bougie run -- bin/console doctrine:migrations:migrate
+bougie run -- bin/console doctrine:fixtures:load
+```
+
+Bougie can also manage Node.js. Install it, then build the frontend (yarn is provided through corepack, pinned by the `packageManager` field in `package.json`):
+
+```sh
+bougie node install lts
+bougie run -- corepack yarn install --force
+bougie run -- corepack yarn build
+```
+
+Open the app with `bougie server open`, or go to the URL printed by `bougie start` (something like `http://mijnrood.bougie.run:7080`). You should be greeted by the MijnRood login page; test accounts are listed under [Local test login data](#local-test-login-data).
+
+Any Symfony console command can be run through bougie, e.g.:
+
+`bougie run -- bin/console doctrine:migrations:diff`
+
+## Setup with docker-compose
+
 The docker-compose file creates four containers:
 1. An nginx load balancer
 2. A PHP server
@@ -75,7 +122,7 @@ Member level:
 - Find your authentication token at dashboard.ngrok.com/get-started/your-authtoken and register it with your client:
 `ngrok config add-authtoken <YOUR AUTH TOKEN HERE>`
 - Start ngrok:
-`ngrok http 8080`
+`ngrok http 8080` (use port 7080 for the bougie setup)
 - Set `COOKIE_DOMAIN` to the domain (without http(s)://) mentioned in the `Forwarding` row in `.env.local`:
 `COOKIE_DOMAIN=<YOUR URL HERE>.ngrok-free.app`
 - Open the URL mentioned in the `Forwarding` row instead of `localhost:8080`.

--- a/composer.json
+++ b/composer.json
@@ -1,112 +1,122 @@
 {
-    "type": "project",
-    "license": "proprietary",
-    "require": {
-        "php": ">=8.1",
-        "ext-ctype": "*",
-        "ext-iconv": "*",
-        "composer/package-versions-deprecated": "1.11.99.1",
-        "doctrine/annotations": "^1.0",
-        "doctrine/doctrine-bundle": "^2.2",
-        "doctrine/doctrine-migrations-bundle": "^3.0",
-        "doctrine/orm": "^2.7",
-        "easycorp/easyadmin-bundle": "^3.1",
-        "friendsofsymfony/jsrouting-bundle": "^2.7",
-        "mollie/mollie-api-php": "^2.0",
-        "phpdocumentor/reflection-docblock": "^5.2",
-        "phpoffice/phpspreadsheet": "^1.17",
-        "sensio/framework-extra-bundle": "^5.1",
-        "symfony/asset": "5.4.*",
-        "symfony/console": "5.4.*",
-        "symfony/dotenv": "5.4.*",
-        "symfony/expression-language": "5.4.*",
-        "symfony/flex": "^1.3.1",
-        "symfony/form": "5.4.*",
-        "symfony/framework-bundle": "5.4.*",
-        "symfony/http-client": "5.4.*",
-        "symfony/intl": "5.4.*",
-        "symfony/mailer": "5.4.*",
-        "symfony/mime": "5.4.*",
-        "symfony/monolog-bundle": "^3.1",
-        "symfony/notifier": "5.4.*",
-        "symfony/process": "5.4.*",
-        "symfony/property-access": "5.4.*",
-        "symfony/property-info": "5.4.*",
-        "symfony/security-bundle": "5.4.*",
-        "symfony/serializer": "5.4.*",
-        "symfony/string": "5.4.*",
-        "symfony/translation": "5.4.*",
-        "symfony/twig-bundle": "^5.1",
-        "symfony/validator": "5.4.*",
-        "symfony/web-link": "5.4.*",
-        "symfony/webpack-encore-bundle": "^1.11",
-        "symfony/yaml": "5.4.*",
-        "twig/extra-bundle": "^3.1",
-        "twig/intl-extra": "^3.1",
-        "twig/twig": "^2.12|^3.0"
+  "type": "project",
+  "license": "proprietary",
+  "require": {
+    "php": ">=8.1",
+    "ext-ctype": "*",
+    "ext-iconv": "*",
+    "ext-pdo_mysql": "*",
+    "composer/package-versions-deprecated": "1.11.99.1",
+    "doctrine/annotations": "^1.0",
+    "doctrine/doctrine-bundle": "^2.2",
+    "doctrine/doctrine-migrations-bundle": "^3.0",
+    "doctrine/orm": "^2.7",
+    "easycorp/easyadmin-bundle": "^3.1",
+    "friendsofsymfony/jsrouting-bundle": "^2.7",
+    "mollie/mollie-api-php": "^2.0",
+    "phpdocumentor/reflection-docblock": "^5.2",
+    "phpoffice/phpspreadsheet": "^1.17",
+    "sensio/framework-extra-bundle": "^5.1",
+    "symfony/asset": "5.4.*",
+    "symfony/console": "5.4.*",
+    "symfony/dotenv": "5.4.*",
+    "symfony/expression-language": "5.4.*",
+    "symfony/flex": "^1.3.1",
+    "symfony/form": "5.4.*",
+    "symfony/framework-bundle": "5.4.*",
+    "symfony/http-client": "5.4.*",
+    "symfony/intl": "5.4.*",
+    "symfony/mailer": "5.4.*",
+    "symfony/mime": "5.4.*",
+    "symfony/monolog-bundle": "^3.1",
+    "symfony/notifier": "5.4.*",
+    "symfony/process": "5.4.*",
+    "symfony/property-access": "5.4.*",
+    "symfony/property-info": "5.4.*",
+    "symfony/security-bundle": "5.4.*",
+    "symfony/serializer": "5.4.*",
+    "symfony/string": "5.4.*",
+    "symfony/translation": "5.4.*",
+    "symfony/twig-bundle": "^5.1",
+    "symfony/validator": "5.4.*",
+    "symfony/web-link": "5.4.*",
+    "symfony/webpack-encore-bundle": "^1.11",
+    "symfony/yaml": "5.4.*",
+    "twig/extra-bundle": "^3.1",
+    "twig/intl-extra": "^3.1",
+    "twig/twig": "^2.12|^3.0"
+  },
+  "require-dev": {
+    "doctrine/doctrine-fixtures-bundle": "^3.4",
+    "symfony/browser-kit": "^5.1",
+    "symfony/css-selector": "^5.1",
+    "symfony/debug-bundle": "^5.1",
+    "symfony/maker-bundle": "^1.0",
+    "symfony/phpunit-bridge": "^5.1",
+    "symfony/stopwatch": "^5.1",
+    "symfony/var-dumper": "^5.1",
+    "symfony/web-profiler-bundle": "^5.1"
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": {
+      "*": "dist"
     },
-    "require-dev": {
-        "doctrine/doctrine-fixtures-bundle": "^3.4",
-        "symfony/browser-kit": "^5.1",
-        "symfony/css-selector": "^5.1",
-        "symfony/debug-bundle": "^5.1",
-        "symfony/maker-bundle": "^1.0",
-        "symfony/phpunit-bridge": "^5.1",
-        "symfony/stopwatch": "^5.1",
-        "symfony/var-dumper": "^5.1",
-        "symfony/web-profiler-bundle": "^5.1"
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "symfony/flex": true
+    }
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  },
+  "replace": {
+    "paragonie/random_compat": "2.*",
+    "symfony/polyfill-ctype": "*",
+    "symfony/polyfill-iconv": "*",
+    "symfony/polyfill-php72": "*",
+    "symfony/polyfill-php71": "*",
+    "symfony/polyfill-php70": "*",
+    "symfony/polyfill-php56": "*"
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
     },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": {
-            "*": "dist"
-        },
-        "sort-packages": true,
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "symfony/flex": true
-        }
+    "post-install-cmd": [
+      "@auto-scripts"
+    ],
+    "post-update-cmd": [
+      "@auto-scripts"
+    ]
+  },
+  "conflict": {
+    "symfony/symfony": "*"
+  },
+  "extra": {
+    "symfony": {
+      "allow-contrib": false,
+      "require": "5.4.*"
     },
-    "autoload": {
-        "psr-4": {
-            "App\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "App\\Tests\\": "tests/"
-        }
-    },
-    "replace": {
-        "paragonie/random_compat": "2.*",
-        "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-iconv": "*",
-        "symfony/polyfill-php72": "*",
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php56": "*"
-    },
-    "scripts": {
-        "auto-scripts": {
-            "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
-        },
-        "post-install-cmd": [
-            "@auto-scripts"
-        ],
-        "post-update-cmd": [
-            "@auto-scripts"
-        ]
-    },
-    "conflict": {
-        "symfony/symfony": "*"
-    },
-    "extra": {
-        "symfony": {
-            "allow-contrib": false,
-            "require": "5.4.*"
-        }
-    },
-    "name": "rood/mijnrood",
-    "description": ""
+    "bougie": {
+      "services": {
+        "mariadb": "*",
+        "server": "*"
+      },
+      "php": {
+        "version": "8.1"
+      }
+    }
+  },
+  "name": "rood/mijnrood",
+  "description": ""
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c87c29dacc1b1eece409e974fed4ede",
+    "content-hash": "cad0bd9675beb6b2aa9b7524475d54ee",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -9506,7 +9506,8 @@
     "platform": {
         "php": ">=8.1",
         "ext-ctype": "*",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-pdo_mysql": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
         "jquery": "^3.6.0",
         "less": "^4.0.0",
         "less-loader": "^12.2.0"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
bougie (https://bougie.tools) manages the PHP toolchain, composer dependencies, Node.js, and dev services (MariaDB + HTTP server), so no Docker is needed for local development.

- composer.json: declare PHP 8.1 and the mariadb/server services under extra.bougie, and require ext-pdo_mysql
- package.json: pin yarn via the packageManager field so corepack provides it
- README.md: document the bougie setup as the recommended path